### PR TITLE
URI decode header value

### DIFF
--- a/lib/fluent/plugin/out_http_shadow.rb
+++ b/lib/fluent/plugin/out_http_shadow.rb
@@ -151,7 +151,7 @@ module Fluent
     def get_header(record)
       header = {}
       @headers.each do |k, v|
-        value = v.result(binding)
+        value = URI.decode(v.result(binding)) # because values are sometimes URI encoded
         if @no_send_header_pattern
           header[k] = value unless @no_send_header_pattern.match(value)
         else


### PR DESCRIPTION
This PR change is for Quipper's specific problem.
We are using a cookie value as HTTP header, which is URL encoded. So we have to decode it.